### PR TITLE
Autocreate Darbee

### DIFF
--- a/mod.lua
+++ b/mod.lua
@@ -1,8 +1,8 @@
 MOD_NAME = "honeycomb_furniture"
 MOD_NAME_FRIENDLY = "Honeycomb Furniture"
-DEV_MODE_ENABLED = true
-LOGGING_SUCCESSES_ENABLED = true
-LOGGING_FAILURES_ENABLED = true
+DEV_MODE_ENABLED = false
+LOGGING_SUCCESSES_ENABLED = false
+LOGGING_FAILURES_ENABLED = false
 LOGGING_INFO_ENABLED = false
 
 ----------------------------------------------------
@@ -13,7 +13,7 @@ function register()
 
     return {
       name = MOD_NAME,
-      hooks = {"key"}, 
+      hooks = {"key", "ready"}, 
       modules = {"objects", "menus", "npcs", "utilities"} 
     }
 
@@ -40,6 +40,17 @@ function init()
 end
 
 ----------------------------------------------------
+-- READY
+----------------------------------------------------
+
+function ready()
+
+  -- Create Darbee NPC if he doesn't exist.
+  create_npc("npc325")
+  return "Success"
+end
+
+----------------------------------------------------
 -- KEY
 ----------------------------------------------------
 key_f5 = 116
@@ -48,6 +59,7 @@ function key(key_code)
 
   if key_code == key_f5 then
 
+    -- Rotate Darbee's shop stock when F5 is pressed.
     if api_get_property(
       api_get_property(
           api_get_menu_objects(nil, "npc325")[1]["menu_id"],

--- a/modules/npcs.lua
+++ b/modules/npcs.lua
@@ -75,9 +75,6 @@ end
 ---@param npc_oid string The OID of the NPC that should be created.
 ---
 function create_npc(npc_oid)
-    check_objects = api_get_objects(nil, npc_oid)
-    mod_log_info(module_object_name .. ".create_npc check_objects:", check_objects)
-    mod_log_info(module_object_name .. ".create_npc #check_objects:", #check_objects)
 
     -- Get all of the menu objects for a given NPC OID. We don't need the full NPC object information, only the IDs.
     npc_all_objects = api_all_menu_objects(npc_oid)

--- a/modules/npcs.lua
+++ b/modules/npcs.lua
@@ -48,7 +48,7 @@ function define_darbee()
             stock = shop_stock_darbee[darbee_stock_index],
             greeting = "It's a bee-autiful day for furniture shopping.",
             dialogue = {"My grandpoppy taught me how to make honeycomb furniture.","It's fulfilling carrying on family traditions."},
-            walking = true,
+            walking = false,
             shop = true
         },
         "sprites/npc/darbee_standing.png",
@@ -65,6 +65,54 @@ function define_darbee()
     return mod_log_status(define_darbee_status, function_name, log_message)
 
 
+end
+
+----------------------------------------------------
+-- CREATE NPCs
+----------------------------------------------------
+
+--- Check if an NPC exists on the map or in the player's inventory. If there is not an active instance or an item in the player's inventory, give the player the NPC item to place where they wish.
+---@param npc_oid string The OID of the NPC that should be created.
+---
+function create_npc(npc_oid)
+    check_objects = api_get_objects(nil, npc_oid)
+    mod_log_info(module_object_name .. ".create_npc check_objects:", check_objects)
+    mod_log_info(module_object_name .. ".create_npc #check_objects:", #check_objects)
+
+    -- Get all of the menu objects for a given NPC OID. We don't need the full NPC object information, only the IDs.
+    npc_all_objects = api_all_menu_objects(npc_oid)
+
+    -- If no NPC menu objects exist, spawn the NPC as an item into the player's inventory
+    if #npc_all_objects == 0 then
+
+        player = api_get_player_instance()
+        player_slots = api_get_slots(player)
+        npc_inventory_count = 0
+
+        -- Don't give the player another NPC item if there's already one in their player inventory.
+        for slot=1, #player_slots do
+            slot_info = api_get_slot(player, slot)
+
+            if slot_info["item"] == npc_oid then
+                npc_inventory_count = npc_inventory_count + 1
+            end
+        end
+
+
+       -- Give the player an NPC item that they can place where they want, rather than creating it directly on the map.
+        if npc_inventory_count == 0 then
+            api_give_item(npc_oid, 1)           
+        end
+
+
+    -- If there is more than one NPC menu object active in the world, remove the extras
+    elseif #npc_all_objects > 1 then
+        
+        for npc=2, #npc_all_objects do
+            mod_log_info(module_object_name .. '.create_npc >1 npc_all_objects[npc]', npc_all_objects[npc])
+            api_destroy_inst(npc_all_objects[npc])
+        end
+    end
 end
 
 ----------------------------------------------------
@@ -172,3 +220,4 @@ function rotate_darbee_stock(npc_id, npc_full_stock)
 
     end
 end
+

--- a/modules/utilities.lua
+++ b/modules/utilities.lua
@@ -12,6 +12,11 @@ function set_dev_mode()
             "/honeycomb_one_of_everything",
             "gimme_one_of_everything"
         )
+        -- NPCs cannot be deleted via bin. This allows devs to do this for testing. Place the NPC on the map and then run the command.
+        api_define_command(
+            "/destroy_npc",
+            "destroy_npc"
+        )
     end
     
 end
@@ -98,7 +103,7 @@ function iterate_elements(element_collection)
 end
 
 ----------------------------------------------------
--- DEV MODE HELPER GIVE ONE OF EVERYTHING
+-- DEV MODE HELPERS
 ----------------------------------------------------
 
 
@@ -113,6 +118,17 @@ function gimme_one_of_everything()
     api_give_item(construct_id("bee_plush_happy"), 1)
     api_give_item(construct_id("honeycomb_crate_large"), 1)
     api_give_item(construct_id("honeycomb_crate_small"), 1)
+
+end
+
+-- Destroy an NPC by its OID since NPCs can't be deleted via bin. 
+---@param args string The OID of the NPC to destroy all active instances of.
+function destroy_npc(args)
+    npc_all_objects = api_all_menu_objects(args[1])
+
+    for npc=0, #npc_all_objects do
+        api_destroy_inst(npc_all_objects[npc])
+    end
 
 end
 


### PR DESCRIPTION
- Auto-add NPC item to player inventory if NPC does not exist in the world or the player's inventory. 
- Changed Darbee NPC to not walk to make him easier to find. 
- Added a dev mode utility to delete all active NPCs of a given OID.

Closes #4 